### PR TITLE
Removed declaration in starter code that student's are instructed to add

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -52,7 +52,6 @@ header .donate-link {
   padding: 10px 30px;
   color: white;
   /* add align-self; flex-end; to overwrite align-items: center; from the parent container */
-  align-self: flex-end;
   border-radius: 5px;
 }
 


### PR DESCRIPTION
Removed align-self; flex-end; declaration from the header .donate-link rule in the tablet media queries. The lesson text instructs the student to add it to overwrite the mobile styles. 